### PR TITLE
Add support to specify the degrees of the rotation by the rotate attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ With a GeoJSON containing lines, it becomes:
 * `center` Centers the text according to the polyline's bounding box  (Default: `false`)
 * `attributes` Object containing the attributes applied to the `text` tag. Check valid attributes [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/text#Attributes) (Default: `{}`)
 * `below` Show text below the path (Default: false)
-* `rotate` Turn every character of the text 90 degrees to the right (Default: false)
+* `rotate` Turn every character of the text clockwise with the specified degrees. Although any angle value may be used, the value is determined by rounding it to the nearest multiple of 90 degrees. (Default: 0)
 
 Screenshot
 ----------

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
         var alpha = L.polyline([[29.53522956294847,119.88281249999999],[25.165173368663954, 156.09375], [37.16031654673677,185.2734375],[-8.05922962720018, 204.9609375]]).addTo(map)
         alpha.setText('A ', {repeat: true,
-                             rotate: true,
+                             rotate: 270,
                              attributes: {fill: 'purple',
                                           'font-size': '12'}});
 

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -106,9 +106,10 @@ var PolylineTextPath = {
         textNode.appendChild(textPath);
         this._textNode = textNode;
 
-        if (options.rotate) {
+        if (parseInt(options.rotate)) {
             var textNodeStyle = textNode.getAttribute("style") ? textNode.getAttribute("style") : "";
-            textNodeStyle += "writing-mode: tb; glyph-orientation-vertical: 180;";
+            var rotation = options.rotate + 90;
+            textNodeStyle += "writing-mode: tb; glyph-orientation-vertical: " + rotation + ";";
             textNode.setAttribute("style",  textNodeStyle);
         }
 

--- a/leaflet.textpath.js
+++ b/leaflet.textpath.js
@@ -58,7 +58,7 @@ var PolylineTextPath = {
             fillColor: 'black',
             attributes: {},
             below: false,
-            rotate: false
+            rotate: 0
         };
         options = L.Util.extend(defaults, options);
 


### PR DESCRIPTION
It could be nice to specify the degrees of the rotation by the rotate attribute, instead of rotate the characters by hardcoded 90 degrees.
Although any angle value may be used, the value is determined by rounding it to the nearest multiple of 90 degrees. This is a cause of using `glyph-orientation-vertical` property (https://www.w3.org/TR/2003/CR-css3-text-20030514/#glyph-orientation-vertical).
